### PR TITLE
Update building_the_backend.md

### DIFF
--- a/docs/src/development/building_the_backend.md
+++ b/docs/src/development/building_the_backend.md
@@ -1,9 +1,12 @@
+![image](https://github.com/LunaAsefaw/rezoning-2-project/assets/90245715/667fe560-1cc6-4721-b60b-a0fd460e1d2b)
+
 ## How to run the backend locally:
 
-The API of rezoning contains 2 parts: the **Rezoning API** and the **Export Function**. Each need to be ran individually. But before running any of the 2, localstack needs to be running.
+The API for rezoning contains two parts: the **Rezoning API** and the **Export Function**. Each needs to be run individually. But before running any of the two, localstack needs to be running.
 
-## Clone repo & checkout to development branch:
-First you need to fetch the source code for the backend using the following command:  
+
+## Clone repo & checkout to the development branch:
+First, you need to fetch the source code for the backend using the following command:  
 
 ```
 git clone https://github.com/worldbank/WB-rezoning-explorer-api.git
@@ -36,10 +39,16 @@ localstack start -d
 
 
 - ## Install aws cli tool:
-    - Install AWS CLI tools by following instructions from: [Installing or updating the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+    - Install AWS CLI tools by following instructions from [Installing or updating the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
     - Check if aws cli was installed correctly using ```aws --version```: this will display the version of the installed aws-cli toolchain.
 
+- Set up AWS configuration:
+```
+  aws configure
 
+```
+  It will ask for AWS Access Key, AWS Secret Key and Region, for example us-east-2.
+  
 - Create the SQS queue in localstack:  
 
 ```
@@ -55,7 +64,7 @@ aws s3 mb s3://rezoning-exports --endpoint-url=http://localhost:4566/
 ## Running Rezoning API:
 In order to work with Rezoning locally, you need AWS access to the processed data (Currently around 330Gb of data) and a certain Airtable. 
 
-- You can do this by setting the follwing envirnment variables:  
+- You can do this by setting the following environment variables:  Replace <%> with the keys but omit <%>
 
 ```
 export AIRTABLE_KEY=<%AIRTABLE_KEY> AWS_ACCESS_KEY_ID=<%AWS_ACCESS_KEY_ID> AWS_SECRET_ACCESS_KEY=<%AWS_SECRET_ACCESS_KEY>
@@ -69,7 +78,7 @@ aws s3 cp s3://gre-processed-data/ ~/rezoning-data/
 ```
 
 - Optional:
-To work with the local data, the following envirnment variables need to be set:  
+To work with the local data, the following environment variables need to be set:  
 
 ```
 export REZONING_IS_LOCAL_DEV=True
@@ -92,14 +101,14 @@ pip install uvicorn
 - Start the server using:
 
 ```
-python -m uvicorn rezoning_api.main:app --reload
+python3 -m uvicorn rezoning_api.main:app --reload
 ```
 
 ### Run export function locally:  
 
-> **Note:**: Make sure to replace **<% %>** placeholders with your AWS information before unning the blow code.
+> **Note:**: Make sure to replace **<% %>** placeholders with your AWS information before running the code below.
 
 ```
 export AIRTABLE_KEY=<%AIRTABLE_KEY> AWS_ACCESS_KEY_ID=<%AWS_ACCESS_KEY_ID> AWS_SECRET_ACCESS_KEY=<%AWS_SECRET_ACCESS_KEY>
-REGION=us-east-2 REZONING_IS_LOCAL_DEV=True QUEUE_NAME=export-queue python ./export/export.py
+REGION=us-east-2 REZONING_IS_LOCAL_DEV=True QUEUE_NAME=export-queue 
 ```

--- a/docs/src/development/building_the_frontend.md
+++ b/docs/src/development/building_the_frontend.md
@@ -1,6 +1,7 @@
+![image](https://github.com/LunaAsefaw/rezoning-2-project/assets/90245715/667fe560-1cc6-4721-b60b-a0fd460e1d2b)
 
 # Clone the frontend:
-First you need to fetch the source code for the frontend using the following command:  
+First, you need to fetch the source code for the frontend using the following command:  
 
 ```
 git clone https://github.com/worldbank/WB-rezoning-explorer.git
@@ -15,7 +16,7 @@ cd WB-rezoning-explorer
 
 # Building the frontend:
 
-To buid the frontend properly a specific version of Node needs to be used.
+To build the frontend properly a specific version of Node needs to be used.
 
 - Setup node version manager (nvm) following instructions from [NVM github](https://github.com/nvm-sh/nvm)
 - install nodejs 12 using the commands:
@@ -24,19 +25,19 @@ nvm install v12
 nvm use v12
 ```  
 
-- Install Yarn on ubunut using:  
+- Install Yarn on ubuntu using:  
 
 ```
 npm install -g yarn
 ```  
 
-- Install npm dependendencies using:
+- Install npm dependencies using:
 
 ```
 yarn install
 ```  
 
-- Start server with live code reload at [http://localhost:9000](http://localhost:9000):  
+- Start the server with live code reload at [http://localhost:9000](http://localhost:9000):  
 
 ```
 yarn serve
@@ -48,9 +49,9 @@ yarn serve
 yarn test
 ```
 
-# Using the front end with different rezoning API deployment setting: 
+# Using the front end with different rezoning API deployment settings: 
 
-- In ```app/scripts/config/``` there are setting files for each envirnment type (local, production or staging).
-- You can set which envirnment to use by setting NODE_ENV envirnment variable to "testing", "staging" or "development". 
+- In ```app/scripts/config/``` there are setting files for each environment type (local, production or staging).
+- You can set which environment to use by setting NODE_ENV environment variable to "testing", "staging" or "development". 
 - You can use a different MapBox key by writing a different mbToken in the config file.
 - apiEndpoint in the settings file indicates the URL to the rezoning-explorer-api in use.


### PR DESCRIPTION
FIxed typos, 
Added aws configure above SQS code because it generates error "You must specify a region. You can also configure your region by running "aws configure". if you run aws sqs create-queue --queue-name export-queue --endpoint-url=http://localhost:4566/ 
Changed python to python 3
Changed the final step to exclude python ./export/export.py because it creates error "bash: export: `./export/export.py': not a valid identifier"

